### PR TITLE
don't import normalize from Base

### DIFF
--- a/src/Dolang.jl
+++ b/src/Dolang.jl
@@ -12,7 +12,7 @@ push!(DOLANG_FUNCTIONS, ARITH_SYMBOLS...)
 
 using Compat: view, String, @compat
 
-import Base: ==, normalize
+import Base: ==
 
 export make_function, Der, FunctionFactory, normalize, is_time_shift, time_shift,
        subs, csubs, steady_state, list_symbols, list_symbols!, list_variables,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,14 +3,7 @@ module DolangTests
 using Dolang
 using Compat
 using DataStructures
-
-
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 tests = length(ARGS) > 0 ? ARGS : [
                                    "symbolic",


### PR DESCRIPTION
all your methods here are on Base types, this is complete type piracy if imported