### PR TITLE
WIP: Albop/simplify symbolic

### DIFF
--- a/src/Dolang.jl
+++ b/src/Dolang.jl
@@ -1,5 +1,4 @@
-# __precompile__(false)
-
+ __precompile__(true)
 module Dolang
 
 using DataStructures

--- a/src/Dolang.jl
+++ b/src/Dolang.jl
@@ -1,4 +1,4 @@
-__precompile__(true)
+# __precompile__(false)
 
 module Dolang
 

--- a/src/compiler_new.jl
+++ b/src/compiler_new.jl
@@ -16,7 +16,7 @@ _sym_sarray(v::Matrix{Symbol}) = Expr(:call, :(SMatrix{$(size(v)...)}), v...)
 
 list_syms(eq::Expr) = get(list_symbols(eq), :parameters, Set{Symbol}())
 list_syms(eq::Symbol) = [eq]
-list_syms(eq::Number) = eq
+list_syms(eq::Number) = Symbol[]
 
 diff_symbol(k::Symbol, j::Symbol) = Symbol("∂", k, "_∂", j)
 

--- a/src/factory.jl
+++ b/src/factory.jl
@@ -77,7 +77,7 @@ function build_definition_map(defs::Associative, incidence::IncidenceTable)
             for time in incidence.by_var[def_var]
                 new_key = normalize((def_var, time))
                 out[new_key] = normalize(
-                    time_shift(_ex, time, funcs, defs)
+                    time_shift(_ex, time, funcs)
                 )
             end
         end
@@ -333,7 +333,13 @@ function FlatFunctionFactory(ff::FunctionFactory; eliminate_definitions=false)
     # we ignore definitions assuming they have already been substituted
     preamble = OrderedDict{Symbol, Expr}()
 
-    FlatFunctionFactory(equations, arguments, targets, preamble, ff.funname)
+    if equations isa Vector
+        eqs = OrderedDict(Symbol("eq_",i)=>eq for (i,eq) in enumerate(equations))
+    else
+        eqs = equations
+    end
+
+    FlatFunctionFactory(eqs, arguments, targets, preamble, ff.funname)
 
 end
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -383,6 +383,9 @@ end
 # list_symbols #
 # ------------ #
 
+#
+list_symbols(ex::Number, other...) = Dict{Symbol,Any}()
+
 """
     list_symbols(::Expr;
                  functions::Union{Set{Symbol},Vector{Symbol}}=Set{Symbol}())

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -337,6 +337,8 @@ steady_state(ex::Union{Symbol, Number}, args...) = ex
 
 #
 list_symbols(ex::Number, other...) = Dict{Symbol,Any}()
+list_symbols(expr::Symbol, other...) =  Dict{Symbol,Any}(:parameters=>[expr])
+
 
 """
     list_symbols(::Expr;
@@ -465,7 +467,7 @@ end
 
 _subs(x::Number, d::Associative, a...) = (x, false)
 
-function _subs(ex::Expr, d::Associative, funcs::Set{Symbol}, shiftit=false)
+function _subs(ex::Expr, d::Associative, funcs::Set{Symbol})
 
     if is_time_shift(ex)
 
@@ -478,17 +480,6 @@ function _subs(ex::Expr, d::Associative, funcs::Set{Symbol}, shiftit=false)
             new_ex = d[ex]
             return new_ex, true
         end
-        if shiftit
-            for ts in (-1,1)
-                if (haskey(d, (var, shift+ts)))
-                    new_ex = time_shift(d[(var, shift+ts)], -ts)
-                    return new_ex, true
-                elseif (haskey(d,ex))
-                    new_ex = time_shift(d[ex], -ts)
-                    return new_ex, true
-                end
-            end
-        end
         # d doesn't have a key in canonical form, so just return here
         return ex, false
     end
@@ -497,7 +488,7 @@ function _subs(ex::Expr, d::Associative, funcs::Set{Symbol}, shiftit=false)
     changed = false
 
     for (i, arg) in enumerate(ex.args)
-        new_arg, arg_changed = _subs(arg, d, funcs, shiftit)
+        new_arg, arg_changed = _subs(arg, d, funcs)
         out_args[i] = new_arg
         changed = changed || arg_changed
     end
@@ -521,7 +512,7 @@ for that expression: `(:x, 1)`
 function subs(ex::Union{Expr,Symbol,Number}, from,
               to::Union{Symbol,Expr,Number},
               funcs::Set{Symbol})
-    _subs(ex, Dict(from=>to), funcs, shiftit)[1]
+    _subs(ex, Dict(from=>to), funcs)[1]
 end
 
 """

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -538,10 +538,18 @@ substitute. For example, to replace `x(1)` with `b/c` you need to have the
 entry `(:x, 1) => :(b/c)` in `d`.
 """
 function subs(ex::Union{Expr,Symbol,Number}, d::Associative,
-              funcs::Set{Symbol})
-    _subs(ex, d, funcs, shiftit)[1]
+              funcs::Set{Symbol}=Set{Symbol}())
+    _subs(ex, d, funcs)[1]
 end
 
+###########
+#         #
+###########
+
+function csubs(expr, d::Associative)
+    dd = reorder_triangular_block(d)
+    subs(expr, dd)
+end
 
 # ---------#
 # arg_name #

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -280,35 +280,17 @@ end
 # steady state #
 # ------------ #
 
-"""
-```julia
-steady_state(s, functions::Set{Symbol}, defs::Associative)
-```
-
-If `s` is not a key in `defs`, return the steady state version of the  `s`
-(essentially s(0)).
-
-Otherwise, return `steady_state(defs[s], functions, defs)`
-
-"""
-function steady_state(s::Union{Symbol,Number}, functions::Set{Symbol})
-
-    if haskey(defs, s)
-        steady_state(defs[s], functions, defs)
-    else
-        s
-    end
-end
 
 """
 ```julia
-steady_state(ex::Expr, functions::Set{Symbol}, defs::Associative)
+steady_state(ex::Expr, functions::Set{Symbol})
 ```
 
 Return the steady state version of `ex`, where all symbols in `args`
 always appear at time 0
 """
-function steady_state(ex::Expr, functions::Set{Symbol}, defs::Associative)
+function steady_state(ex::Expr, functions::Set{Symbol})
+
     if is_time_shift(ex)
         return ex.args[1]
     end
@@ -319,7 +301,7 @@ function steady_state(ex::Expr, functions::Set{Symbol}, defs::Associative)
         if func in DOLANG_FUNCTIONS || func in functions
             out = Expr(:call, func)
             for arg in ex.args[2:end]
-                push!(out.args, steady_state(arg, functions, defs))
+                push!(out.args, steady_state(arg, functions))
             end
             return out
         else
@@ -329,25 +311,25 @@ function steady_state(ex::Expr, functions::Set{Symbol}, defs::Associative)
 
      # otherwise just steady_state all args, but retain expr head
     out = Expr(ex.head)
-    out.args = [steady_state(an_arg, functions, defs) for an_arg in ex.args]
+    out.args = [steady_state(an_arg, functions) for an_arg in ex.args]
     return out
 end
 
 """
 ```julia
 steady_state(ex::Expr;
-             functions::Vector{Symbol}=Vector{Symbol}(),
-             defs::Associative=Dict())
+             functions::Vector{Symbol}=Vector{Symbol}())
 ```
 
 Version of `steady_state` where `functions` and `defs` are keyword arguments
 with default values
 """
 function steady_state(ex::Expr;
-                      functions::Union{Set{Symbol},Vector{Symbol}}=Set{Symbol}(),
-                      defs::Associative=Dict())
-    steady_state(ex, Set(functions), defs)
+                      functions::Union{Set{Symbol},Vector{Symbol}}=Set{Symbol}())
+    steady_state(ex, Set(functions))
 end
+
+steady_state(ex::Union{Symbol, Number}, args...) = ex
 
 # ------------ #
 # list_symbols #

--- a/src/util.jl
+++ b/src/util.jl
@@ -181,16 +181,23 @@ system = Dict(:x=>[:y,:z], :y=>[], :z=>[:y] )
 solve_dependency(system)
 ```
 
-Optionally, one can add specify which subset of variables to solve for.
-Unrequired variables will be ommited in the solution.
+Optionally, one can add specify which subset of variables to solve  so that unrequired variables will be ommited in the solution. In
 
+```
+system = Dict(:x=>[:y,:z], :y=>[], :z=>[:y], :p=>[:x,y,z] )
+solve_dependency(system, [:x,:y,:z])
+
+```
+
+the answer is the same as before since `:p` is not needed to
+define the values of `[:x,:y,:z]`.
 """
-function solve_dependencies(deps::Associative{T,Set{T}}, needed=nothing) where T
+function solve_dependencies(deps::Associative{T,Set{T}}, unknowns=nothing) where T
     solution = []
-    if needed == nothing
+    if unknowns == nothing
         needed = Set(keys(deps))
     else
-        needed = Set(needed)
+        needed = Set(unknowns)
     end
     while length(needed)>0
         tt0 = (length(needed), length(solution))
@@ -218,7 +225,6 @@ function solve_dependencies(deps::Associative{T,Set{T}}, needed=nothing) where T
     return solution
 end
 
-list_symbols(expr::Symbol) = list_symbols(:($expr*2))
 
 function get_dependencies(defs::Associative{T,U}) where T where U
     deps = OrderedDict{Any,Set{Any}}()

--- a/src/util.jl
+++ b/src/util.jl
@@ -242,7 +242,7 @@ Keys are timed variables in canonical form (e.g. `(:v,0)`) at date t=0.
 Values are expressions, possibly referencing key variables at different dates.
 The system is recursively solved for the unknowns, by default the keys.
 """
-function solve_definitions(defs::Associative{Tuple{Symbol, Int}, SymExpr}, unknowns=keys(defs))
+function solve_definitions(defs::Associative{Tuple{Symbol, Int}, <:SymExpr}, unknowns=keys(defs))
     # defs should map timed-vars to expressions.
     defs = deepcopy(defs)
     for (v,t) in collect(keys(defs))

--- a/src/util.jl
+++ b/src/util.jl
@@ -218,6 +218,8 @@ function solve_dependencies(deps::Associative{T,Set{T}}, needed=nothing) where T
     return solution
 end
 
+list_symbols(expr::Symbol) = list_symbols(:($expr*2))
+
 function get_dependencies(defs::Associative{T,U}) where T where U
     deps = OrderedDict{Any,Set{Any}}()
     for (k,v) in (defs)

--- a/test/factory.jl
+++ b/test/factory.jl
@@ -33,6 +33,12 @@ end
     funname = :myfun
     _FF = Dolang.FunctionFactory
 
+    ff1 = _FF{typeof(args),
+              typeof(params),
+              Dict{Symbol,Expr},
+              DataType}(eqs, args, params, targets, defs, funname,
+                        Dolang.SkipArg)
+
     @testset "  constructors" begin
         # inner constructor directly
         ff1 = _FF{typeof(args),

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -229,40 +229,6 @@ end
 
 end
 
-@testset " csubs()" begin
-    d = Dict(:monty=> :python, :run=>:faster, :eat=>:more)
-    @test Dolang.csubs(:monty, d) == :python
-    @test Dolang.csubs(:Monty, d) == :Monty
-    @test Dolang.csubs(1.0, d) == 1.0
-
-    want = :(python(faster + more, eats))
-    @test Dolang.csubs(:(monty(run + eat, eats)), d) == want
-
-    for ex in [:(a + b(0) + b(1)), :(a + b + b(1))]
-        for key in [:b, (:b, 0)]
-            d = Dict(key => :(c(0) + d(1)))
-            want = :(a + (c(0) + d(1)) + (c(1) + d(2)))
-            @test Dolang.csubs(ex, d) == want
-
-            d = Dict(key => :(c + d(1)))
-            want = :(a + (c + d(1)) + (c + d(2)))
-            @test Dolang.csubs(ex, d) == want
-        end
-    end
-
-    d = Dict((:b, 0) => :(c + d(1)), (:b, 1) => :(c(100) + d(2)))
-    ex = :(a + b + b(1))
-    want = :(a + (c + d(1)) + (c(100) + d(2)))
-    @test Dolang.csubs(ex, d) == want
-
-    # case where subs and csubs aren't the same
-    ex = :(a + b)
-    d = Dict(:b => :(c/a), :c => :(2a))
-    @test Dolang.subs(ex, d) == :(a + c/a)
-    @test Dolang.csubs(ex, d) == :(a + (2a)/a)
-
-end
-
 @testset "arg_name, arg_time, arg_name_time, arg_names" begin
     for i in 1:5
         s = gensym()

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -156,16 +156,6 @@ end
         have = Dolang.time_shift(:(a+b(1) + c(0)), shift)
         @test have == :(a+b($(shift+1)) + c($(shift)))
 
-        # with defs
-        have = Dolang.time_shift(:(a+b(1) + c), shift, defs=defs)
-        @test have == :(b($(shift-1))/c + b($(shift+1)) + c)
-
-        have = Dolang.time_shift(:(a+b(1) + c(0)), shift, defs=defs)
-        @test have == :(b($(shift-1))/c + b($(shift+1)) + c($(shift)))
-
-        # note that defs have to be sanitized
-        have = Dolang.time_shift(:(a+b(1) + c(0)), shift, defs=defs_sanitized)
-        @test have == :(b($(shift-1))/c($(shift)) + b($(shift+1)) + c($(shift)))
 
         # unknown function
         @test_throws Dolang.UnknownFunctionError Dolang.time_shift(:(a+b(1) + foobar(c)), shift)
@@ -173,19 +163,11 @@ end
         # with functions
         have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift, functions=funcs)
         @test have == :(a+b($(shift+1)) + foobar(c))
-
-        # functions + defs
-        have = Dolang.time_shift(:(a+b(1) + foobar(c)), shift, defs=defs, functions=funcs)
-        @test have == :(b($(shift-1))/c + b($(shift+1)) + foobar(c))
     end
 end
 
 @testset "Dolang.steady_state" begin
     @test Dolang.steady_state(:(a+b(1) + c)) == :(a+b+c)
-
-    # with defs
-    have = Dolang.steady_state(:(a+b(1) + c), defs=Dict(:a=>:(b(-1)/c)))
-    @test have == :(b/c+b+c)
 
     # unknown function
     @test_throws Dolang.UnknownFunctionError Dolang.steady_state(:(a+b(1)+c+foobar(c)))

--- a/test/util.jl
+++ b/test/util.jl
@@ -97,3 +97,74 @@
 
 
 end  # @testset "util"
+
+
+@testset "triangular systems" begin
+
+    @testset "solve_dependencies" begin
+        system_ints = Dict{Int,Set{Int}}(
+            1=>Set([2,3,4]),
+            2=>Set([3,4]),
+            3=>Set([4]),
+            4=>Set([])
+        )
+        sol = Dolang.solve_dependencies(system_ints)
+        @test sol==[4,3,2,1]
+
+        system_syms = Dict{Any,Set{Any}}(
+            :d=>Set([(:a,0),:b,:c]),
+            :c=>Set([(:a,0),:b]),
+            :b=>Set([(:a,0)]),
+            (:a,0)=>Set([])
+        )
+        sol = Dolang.solve_dependencies(system_syms)
+        @test sol==[(:a,0),:b,:c,:d]
+
+        system_error = Dict{Any,Set{Any}}(
+            :d=>Set([(:a,0),:b,:c]),
+            :c=>Set([(:a,0),:b]),
+            :b=>Set([(:a,0)]),
+            (:a,0)=>Set([:d])
+        )
+        @test_throws Dolang.TriangularSystemException Dolang.solve_dependencies(system_error)
+    end
+
+    @testset "Reorder triangular block" begin
+        eqs = Dict(
+            (:k,0)=>:((1-delta)*k(-1)+i(-1)),
+            (:y,0)=>:(A(0)*k(-1)^theta),
+            (:A,0)=>:(rho*A(-1)+epsilon),
+        )
+        eqs_reordered = OrderedDict(
+            (:A, 0) => :(rho * A(-1) + epsilon),
+            (:y, 0) => :(A(0) * k(-1) ^ theta),
+            (:k, 0) => :((1 - delta) * k(-1) + i(-1))
+        )
+        @test eqs_reordered == Dolang.reorder_triangular_block(eqs)
+    end
+
+    @testset "Solve definitions" begin
+
+        defs = Dict(
+            (:V, 0)   => :(c ^ (1 - gamma) / (1 - gamma)),
+            (:c, 0)   => :(y(0) ^ theta - i(0)),
+            (:rho, 0) => :(c(0) / c(-1))
+        )
+        solved_defs = OrderedDict(
+            (:V, 0)   => :(c ^ (1 - gamma) / (1 - gamma)),
+            (:c, 0)   => :(y(0) ^ theta - i(0)),
+            (:c, -1)  => :(y(-1) ^ theta - i(-1)),
+            (:rho, 0) => :(c(0) / c(-1))
+        )
+        @test soved_defs == Dolang.solve_definitions(defs)
+
+        solved_defs_reduced = OrderedDict(
+            (:c, 1)   => :(y(1) ^ theta - i(1)),
+            (:c, 0)  => :(y(0) ^ theta - i(0)),
+            (:rho, 1) => :(c(1) / c(0))
+        )
+
+        @test solved_defs_reduced == Dolang.solve_definitions(defs, [(:rho,1)])
+
+    end
+end

--- a/test/util.jl
+++ b/test/util.jl
@@ -156,7 +156,7 @@ end  # @testset "util"
             (:c, -1)  => :(y(-1) ^ theta - i(-1)),
             (:rho, 0) => :(c(0) / c(-1))
         )
-        @test soved_defs == Dolang.solve_definitions(defs)
+        @test solved_defs == Dolang.solve_definitions(defs)
 
         solved_defs_reduced = OrderedDict(
             (:c, 1)   => :(y(1) ^ theta - i(1)),


### PR DESCRIPTION
The goal of this PR is to simplify the symbolic code and separate unrelated functions. In particular, the way `subs` and `csubs` were doing recursive substitutions seemed quite dangerous to me.
The main changes are:
- some new functions in util.jl to solve for triangular systems:
    - `solve_dependencies`:  solves a triangular system coded as a dependency dict (like `Dict(:a=>[], :b=>[:a,:c], :c=>[:a])` . It works for any hashable type.
   - `get_dependencies` construct a dependency dict from a mapping with equations as keys (like `Dict(:a=>:(2+p), :b=>:(a+c*x), :c=>:(a*z + d)`. The dependencies are only function of the keys (in this example they discard `(p,x,d)`)
   - `reorder_triangular_block` takes a mapping key/equations and reorder it so that it can be evaluated sequentially
   - `solve_definitions` solves for a key equation mapping where keys are of the form `(:v,0)` and where `(:v,1)` and `(:v,-1)` are implicitly defined, by time shifting the values. If a list of unknown is specidfied (like `(:rho, 1)`) only the variables required  to define this unknown will be part of the solution (in this case `(:c,1)`, `(:c,1)` )
- symbolic.jl: 
   - subs, and steady_state, don't take a `defs` argument anymore.
   - there is a backward compatible implementation of `csubs` but I'd like to deprecate it in the future to separate the solution of definitions and the substitutions. We could rename in `psubs` (for pattern), so that `x(t)=>y(t)+z(t)` would define implicitly `x(t+1)=>y(t+1)+z(t+1)`

There is now an explicit restriction of what we call a `definitions` block. It must consist in mapping like `d=Dict((:x,0)=>:(a+c), (:y,0)=>:(x(1)+p))`. In particular the left hand side must be at date 0. 

Reading/rewriting some of the code made me wonder what disadvantage the would be in accepting `d=Dict(:(x(0))=>:(a+c), :(y(0))=>:(x(1)+p))`