### PR TITLE
ENH: fix the type-stable val. closes #46

### DIFF
--- a/src/compiler_new.jl
+++ b/src/compiler_new.jl
@@ -348,11 +348,7 @@ function gen_generated_gufun(fff::FlatFunctionFactory; funname=fff.funname, disp
         @generated function $funname($(dispatch_arg...), orders::Union{Val,Type{<:Val}}, $(args...), out=nothing)
             fff = $(fff) # this is amazing !
             _oorders = collect(Dolang._get_nums(orders)) # convert into tuples
-            if length(_oorders) == 1
-                oorders = reshape(_oorders, 1)
-            else
-                oorders = _oorders
-            end
+            oorders = length(_oorders) == 1 ? _oorders[1]: _oorders
             code = Dolang.gen_gufun(fff, oorders)
             code.args[2].args[2]
         end

--- a/src/compiler_new.jl
+++ b/src/compiler_new.jl
@@ -347,7 +347,12 @@ function gen_generated_gufun(fff::FlatFunctionFactory; funname=fff.funname, disp
 
         @generated function $funname($(dispatch_arg...), orders::Union{Val,Type{<:Val}}, $(args...), out=nothing)
             fff = $(fff) # this is amazing !
-            oorders = collect(Dolang._get_nums(orders)) # convert into tuples
+            _oorders = collect(Dolang._get_nums(orders)) # convert into tuples
+            if length(_oorders) == 1
+                oorders = reshape(_oorders, 1)
+            else
+                oorders = _oorders
+            end
             code = Dolang.gen_gufun(fff, oorders)
             code.args[2].args[2]
         end

--- a/src/compiler_new.jl
+++ b/src/compiler_new.jl
@@ -350,12 +350,7 @@ function gen_generated_gufun(fff::FlatFunctionFactory; funname=fff.funname, disp
 
         @generated function $funname($(dispatch_arg...), orders::Union{Val,Type{<:Val}}, $(args...), out=nothing)
             fff = $(fff) # this is amazing !
-<<<<<<< HEAD
             oorders = _get_oorders(collect(Dolang._get_nums(orders)))
-=======
-            _oorders = collect(Dolang._get_nums(orders)) # convert into tuples
-            oorders = length(_oorders) == 1 ? _oorders[1] : _oorders
->>>>>>> 10d391520885e3de70d2db5fe73159fed47537de
             code = Dolang.gen_gufun(fff, oorders)
             code.args[2].args[2]
         end

--- a/src/compiler_new.jl
+++ b/src/compiler_new.jl
@@ -210,7 +210,7 @@ If at least one of the arguments is a list of points, the result is a list of
 points (or a tuple mad of lists of points). In this case preallocated
 structures can be passed as `out`.
 """
-function gen_gufun(fff::FlatFunctionFactory, to_diff::Union{Vector{Int}, Int};
+function gen_gufun(fff::FlatFunctionFactory, to_diff::Union{Array{Int}, Int};
     funname=fff.funname)
 
     if to_diff isa Int
@@ -311,6 +311,9 @@ end
 
 _get_nums(::Union{Val{n}, Type{Val{n}}, Type{Type{Val{n}}}}) where n = n
 _get_nums(t::Type{<:Tuple}) = [_get_nums(i) for i in getfield(t, 3)]
+_get_oorders(x::Array{Int,0}) = x[1]
+_get_oorders(x::Union{Tuple,<:Array{Int}}) = x
+
 
 function gen_generated_kernel(fff::FlatFunctionFactory)
 
@@ -347,8 +350,7 @@ function gen_generated_gufun(fff::FlatFunctionFactory; funname=fff.funname, disp
 
         @generated function $funname($(dispatch_arg...), orders::Union{Val,Type{<:Val}}, $(args...), out=nothing)
             fff = $(fff) # this is amazing !
-            _oorders = collect(Dolang._get_nums(orders)) # convert into tuples
-            oorders = length(_oorders) == 1 ? _oorders[1]: _oorders
+            oorders = _get_oorders(collect(Dolang._get_nums(orders)))
             code = Dolang.gen_gufun(fff, oorders)
             code.args[2].args[2]
         end

--- a/test/compiler_new.jl
+++ b/test/compiler_new.jl
@@ -147,6 +147,7 @@ p_mat = Dolang.from_SA(p_vec)
 
         @test isa(@inferred(gengufun(Val{0}, x, y, z, p)), SVector{2,Float64})
         @test isa(@inferred(gengufun(Val{1}, x, y, z, p)), StaticArrays.SArray{Tuple{2,1},Float64,2,2})
+        @test isa(@inferred(gengufun(Val{(1,)}, x, y, z, p)), Tuple{StaticArrays.SArray{Tuple{2,1},Float64,2,2}})
 
     end
 

--- a/test/compiler_new.jl
+++ b/test/compiler_new.jl
@@ -145,6 +145,9 @@ p_mat = Dolang.from_SA(p_vec)
             @test isa(res3, Tuple{Array{SVector{2, Float64},1},Array{StaticArrays.SArray{Tuple{2,1},Float64,2,2},1},Array{StaticArrays.SArray{Tuple{2,2},Float64,2,4},1}})
         end
 
+        @test isa(@inferred(gengufun(Val{0}, x, y, z, p)), SVector{2,Float64})
+        @test isa(@inferred(gengufun(Val{1}, x, y, z, p)), StaticArrays.SArray{Tuple{2,1},Float64,2,2})
+
     end
 
 end


### PR DESCRIPTION
With this commit you can do 

```
julia> gengufun(Val{(1,2,3)}, x, y, z, p)
([-0.35; 0.0], [0.5 0.7 -0.5; 0.0 0.0 0.0], [0.0 0.0; 1.0 0.1])

julia> gengufun(Val{1}, x, y, z, p)
([-0.35; 0.0],)

julia> gengufun(Val{(1,2,3)}(), x, y, z, p)
([-0.35; 0.0], [0.5 0.7 -0.5; 0.0 0.0 0.0], [0.0 0.0; 1.0 0.1])

julia> gengufun(Val{1}(), x, y, z, p)
([-0.35; 0.0],)
```

and they are all type stable