### PR TITLE
ENH: compatibility with 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   # - osx  # we don't do any binary dependencies or OS specific magic
 julia:
   - 0.6
+  - 0.7
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -749,25 +749,33 @@ function make_function(ff::FunctionFactory)
     sig = super_signature(ff, signature)
     body = Expr(:block, :(ff = $ff), :(Dolang.func_body(ff, Der{D})))
     gen_func_body = Expr(:function, sig, body)
-    push!(out.args, Expr(:macrocall, Symbol("@generated"), gen_func_body))
+    # push!(out.args, Expr(:macrocall, Symbol("@generated"), gen_func_body))
+    push!(out.args, :(@generated $gen_func_body))
+
 
     # make generated, mutating function
     sig! = super_signature(ff, signature!)
     body! = Expr(:block, :(ff = $ff), :(Dolang.func_body!(ff, Der{D})))
     gen_func!_body = Expr(:function, sig!, body!)
-    push!(out.args, Expr(:macrocall, Symbol("@generated"), gen_func!_body))
+    # push!(out.args, Expr(:macrocall, Symbol("@generated"), gen_func!_body))
+    push!(out.args, :(@generated $gen_func!_body))
+
 
     # NOTE: I add these specializations to overcome method abiguity introduced
     #       by the vectorized routines below
     sig0 = signature(ff, Der{0})
     body0 = Expr(:block, :(ff = $ff), :(Dolang.func_body(ff, Der{0})))
     func_body0 = Expr(:function, sig0, body0)
-    push!(out.args, Expr(:macrocall, Symbol("@generated"), func_body0))
+    # push!(out.args, Expr(:macrocall, Symbol("@generated"), func_body0))
+    push!(out.args, :(@generated $func_body0))
+
 
     sig0! = signature!(ff, Der{0})
     body0! = Expr(:block, :(ff = $ff), :(Dolang.func_body!(ff, Der{0})))
     func_body0! = Expr(:function, sig0!, body0!)
-    push!(out.args, Expr(:macrocall, Symbol("@generated"), func_body0!))
+    # push!(out.args, Expr(:macrocall, Symbol("@generated"), func_body0!))
+    push!(out.args, :(@generated $func_body0!))
+
 
     # also make a method(s) without the Der{0} for backwards compat
     for sig_func in (signature, signature!)

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -10,7 +10,6 @@ end
 function NormalizeError(ex::Expr)
     msg = """Dolang does not know how to normalize
     \t$(ex)
-    Perhaps you want to use the keyword arugment `custom` when calling normalize?
     """
     NormalizeError(ex, msg)
 end
@@ -28,8 +27,6 @@ end
 # normalize #
 # --------- #
 
-_empty_normalizer(e) = Nullable{Expr}()
-
 """
     normalize(var::Union{String,Symbol}, n::Integer)
 
@@ -39,7 +36,7 @@ Normalize the string or symbol in the following way:
 - if `n < 0` return `_var_mn_`
 
 """
-function normalize(var::Union{String,Symbol}, n::Integer; custom=nothing)
+function normalize(var::Union{String,Symbol}, n::Integer)
     Symbol(normalize(var), n >= 0 ? "_" : "m", abs(n), "_")
 end
 
@@ -48,7 +45,7 @@ end
 
 Same as `normalize(x[1], x[2])`
 """
-normalize{T<:Integer}(x::Tuple{Symbol,T}; custom=nothing) = normalize(x[1], x[2])
+normalize{T<:Integer}(x::Tuple{Symbol,T}) = normalize(x[1], x[2])
 
 """
     normalize(x::Symbol)
@@ -56,7 +53,7 @@ normalize{T<:Integer}(x::Tuple{Symbol,T}; custom=nothing) = normalize(x[1], x[2]
 Normalize the symbol by returning `_x_` if `x` doesn't alread have leading
 and trailling `_` characters
 """
-function normalize(x::Symbol; custom=nothing)
+function normalize(x::Symbol)
     str_x = string(x)
     if str_x[1] == str_x[end] == '_'
         return x
@@ -70,7 +67,7 @@ end
 
 Just return `x`
 """
-normalize(x::Number; custom=nothing) = x
+normalize(x::Number) = x
 
 """
     normalize(ex::Expr; targets::Union{Vector{Expr},Vector{Symbol}}=Symbol[])
@@ -88,21 +85,10 @@ below is `input form of ex: returned expression`):
 """
 function normalize(
         ex::Expr;
-        custom::Function=_empty_normalizer,
         targets=Symbol[]
     )
-    # try custom normalizer
-    cust = custom(ex)
-    if !isnull(cust)
-        return get(cust)
-    end
 
     norm_targets = normalize.(targets)
-
-    # define function to recurse over that passes our custom normalizer
-    # this is just convenience so we don't have to set the kwarg so many
-    # times
-    recur(x) = normalize(x, custom=custom)
 
     # make sure `lhs == rhs` is treated the same as `lhs = rhs`
     if (ex.head == :(=)) || (ex.head == :call && ex.args[1] == :(==))
@@ -115,11 +101,11 @@ function normalize(
         end
         # translate lhs = rhs to rhs - lhs
         if isempty(targets)
-            return Expr(:call, :(-), recur(rhs), recur(lhs))
+            return Expr(:call, :(-), normalize(rhs), normalize(lhs))
         end
 
         # ensure lhs is in targets
-        if !(recur(lhs) in norm_targets)
+        if !(normalize(lhs) in norm_targets)
             msg = string(
                 "Error normalizing expression\n\t$(ex)\n",
                 "Expected expression of the form `lhs = rhs` ",
@@ -128,26 +114,26 @@ function normalize(
             throw(NormalizeError(ex, msg))
         end
 
-        return Expr(:(=), recur(lhs), recur(rhs))
+        return Expr(:(=), normalize(lhs), normalize(rhs))
     end
 
 
     if ex.head == :block
         # for 0.5
         if length(ex.args) == 2 && isa(ex.args[1], LineNumberNode)
-            return recur(ex.args[2])
+            return normalize(ex.args[2])
         end
 
         # for 0.6
         if length(ex.args) == 2 && isa(ex.args[1], Expr) && ex.args[1].head == :line
-            return recur(ex.args[2])
+            return normalize(ex.args[2])
         end
 
         # often we have an Expr simliar to the above, except that we have filtered
         # out the line nodes. We end up with a block with one arg.
         # This is that case.
         if length(ex.args) == 1
-            return recur(ex.args[1])
+            return normalize(ex.args[1])
         end
     end
 
@@ -156,7 +142,7 @@ function normalize(
         # translate x(n) --> x__n_ and x(-n) -> x_mn_
         if length(ex.args) == 2 && isa(ex.args[2], Integer)
             if isa(ex.args[1], Symbol)
-                return normalize(ex.args[1], ex.args[2]; custom=custom)
+                return normalize(ex.args[1], ex.args[2])
             else
                 throw(NormalizeError(ex))
             end
@@ -168,11 +154,11 @@ function normalize(
         # single symbol. My current solution is to just swap the order of the
         # `*`
         if ex.args[1] == :(*) && length(ex.args) == 3 && isa(ex.args[2], Number)
-            return Expr(:call, :(*), recur(ex.args[3]), ex.args[2])
+            return Expr(:call, :(*), normalize(ex.args[3]), ex.args[2])
         end
 
         # otherwise it is just some other function call
-        return Expr(:call, ex.args[1], recur.(ex.args[2:end])...)
+        return Expr(:call, ex.args[1], normalize.(ex.args[2:end])...)
     end
 
     throw(NormalizeError(ex))

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -76,7 +76,7 @@ end
     @test have2.args[1] == :(_d_ = Dolang._unpack_var(y, 1))
 end
 
-@testset " _unpack_+?\(::FunctionFactory\)" begin
+@testset " _unpack_+?(::FunctionFactory)" begin
     ordered_args = [(:c, 1), (:d, 1), (:a, 0), (:b, 0), (:c, 0), (:a, -1)]
     @test Dolang.arg_block(ff, :V) == Dolang._unpack_expr(args, :V)
     @test Dolang.param_block(ff, :p) == Dolang._unpack_expr(params, :p)
@@ -623,7 +623,8 @@ end
     x = [0.33, 0.233874]
     p = [0.99, 5.0, 1.0, 23.9579, 0.025, 0.33, 0.8, 0.0, 0.016]
 
-    eval(current_module(), make_function(ff_grouped))
+    code = make_function(ff_grouped)
+    eval(current_module(), code)
 
     # allocating
     want = [1.0123335492995267e-5, 4.255452989987418e-9]

--- a/test/factory.jl
+++ b/test/factory.jl
@@ -104,7 +104,7 @@ end
 
         # check content of exception
         ex = try
-            _FF(bad_eqs, args, params, targets=targets, targets=targets,
+            _FF(bad_eqs, args, params, targets=targets,
                 defs=defs)
            catch e
                e


### PR DESCRIPTION
This is a first step towards 0.7 compatibility. There are still plenty of warnings, probably easy to fix.
I did two compromises:
- removed the `custom` argument to `normalize`. The nullable argument was raising an error and the interest of this `custom` option is not clear to me. One could achieve the same result by just preprocessing an expression.
- the `reinterpret`, `transpose` and other similar functions now return more complicated types, some of them not compatible with `reinterpret`. Not sure whether it's a bug or not, but handing these types is more complicated than before. Hence, the functions `to_SA` and `from_SA` now return a copy. There is a performance cost, but they are there for compatibility only anyway.