### PR TITLE
REF: normalize->stringify to avoid type piracy

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -106,7 +106,7 @@ eqs = [
     :(sin(x(0)) + exp(2*x(1))),
     :(y(0) / (2 * (1 - β))),
 ]
-# NOTE: Arguments can be pre-normalized and contain unicode
+# NOTE: Arguments can be pre-stringified and contain unicode
 variables = [(:x, 0), (:y, 0), :_x__1_, :β]  
 to_diff = 1:3
 code = make_function(eqs, variables, to_diff, dispatch=Int, name=:my_int_fun)

--- a/docs/src/symbolic.md
+++ b/docs/src/symbolic.md
@@ -15,164 +15,164 @@ Pages = ["symbolic.md"]
 Depth = 2
 ```
 
-## `normalize`
+## `stringify`
 
-The `normalize` function converts expressions and symbols into Dolang's internal
+The `stringify` function converts expressions and symbols into Dolang's internal
 representation. There are various methods for this function:
 
 ```@docs
-normalize(::Symbol)
+stringify(::Symbol)
 ```
 
 **Examples**
 
 ```jldoctest
-julia> normalize(:c)
+julia> stringify(:c)
 :_c_
 
-julia> normalize(:_c)
+julia> stringify(:_c)
 :__c_
 
-julia> normalize(:_c_)
+julia> stringify(:_c_)
 :_c_
 
-julia> normalize(:x_ijk)
+julia> stringify(:x_ijk)
 :_x_ijk_
 
-julia> normalize(:x_ijk_)
+julia> stringify(:x_ijk_)
 :_x_ijk__
 
-julia> normalize(:_x_ijk_)
+julia> stringify(:_x_ijk_)
 :_x_ijk_
 ```
 
 ```@docs
-normalize(::Number)
+stringify(::Number)
 ```
 
 **Examples**
 
 ```jldoctest
-julia> normalize(-1)
+julia> stringify(-1)
 -1
 
-julia> normalize(0)
+julia> stringify(0)
 0
 
-julia> normalize(1)
+julia> stringify(1)
 1
 ```in
 
 ```@docs
-normalize(::Symbol, ::Integer)
+stringify(::Symbol, ::Integer)
 ```
 
 **Examples**
 
 ```jldoctest
-julia> normalize(:x, 0)
+julia> stringify(:x, 0)
 :_x__0_
 
-julia> normalize(:x, 1)
+julia> stringify(:x, 1)
 :_x__1_
 
-julia> normalize(:x, -1)
+julia> stringify(:x, -1)
 :_x_m1_
 
-julia> normalize(:x, -100)
+julia> stringify(:x, -100)
 :_x_m100_
 
-julia> normalize("x", 0)
+julia> stringify("x", 0)
 :_x__0_
 
-julia> normalize("x", 1)
+julia> stringify("x", 1)
 :_x__1_
 
-julia> normalize("x", -1)
+julia> stringify("x", -1)
 :_x_m1_
 
-julia> normalize("x", -100)
-:_x_m100_
-```
-
-```@docs
-normalize(::Tuple{Symbol,Integer})
-```
-
-**Examples**
-
-```jldoctest
-julia> normalize((:x, 0))
-:_x__0_
-
-julia> normalize((:x, 1))
-:_x__1_
-
-julia> normalize((:x, -1))
-:_x_m1_
-
-julia> normalize((:x, -100))
+julia> stringify("x", -100)
 :_x_m100_
 ```
 
 ```@docs
-normalize(::Expr)
+stringify(::Tuple{Symbol,Integer})
 ```
 
 **Examples**
 
 ```jldoctest
-julia> normalize(:(a(1) - b - c(2) + d(-1)))
+julia> stringify((:x, 0))
+:_x__0_
+
+julia> stringify((:x, 1))
+:_x__1_
+
+julia> stringify((:x, -1))
+:_x_m1_
+
+julia> stringify((:x, -100))
+:_x_m100_
+```
+
+```@docs
+stringify(::Expr)
+```
+
+**Examples**
+
+```jldoctest
+julia> stringify(:(a(1) - b - c(2) + d(-1)))
 :(((_a__1_ - _b_) - _c__2_) + _d_m1_)
 
-julia> normalize(:(sin(x)))
+julia> stringify(:(sin(x)))
 :(sin(_x_))
 
-julia> normalize(:(sin(x(0))))
+julia> stringify(:(sin(x(0))))
 :(sin(_x__0_))
 
-julia> normalize(:(dot(x, y(1))))
+julia> stringify(:(dot(x, y(1))))
 :(dot(_x_, _y__1_))
 
-julia> normalize(:(beta * c(0)/c(1) * (alpha*y(1)/k(1) * (1-mu(1)) + 1 - delta_k) - 1))
+julia> stringify(:(beta * c(0)/c(1) * (alpha*y(1)/k(1) * (1-mu(1)) + 1 - delta_k) - 1))
 :(((_beta_ * _c__0_) / _c__1_) * ((((_alpha_ * _y__1_) / _k__1_) * (1 - _mu__1_) + 1) - _delta_k_) - 1)
 
-julia> normalize(:(x = log(y(-1))); targets=[:x])  # with targets
+julia> stringify(:(x = log(y(-1))); targets=[:x])  # with targets
 :(_x_ = log(_y_m1_))
 
-julia> normalize(:(x = log(y(-1))))  # without targets
+julia> stringify(:(x = log(y(-1))))  # without targets
 :(log(_y_m1_) - _x_)
 ```
 
 ```@docs
-normalize(::String)
+stringify(::String)
 ```
 
 **Examples**: see above for more
 
 ```jldoctest
-julia> normalize("x = log(y(-1))"; targets=[:x])  # with targets
+julia> stringify("x = log(y(-1))"; targets=[:x])  # with targets
 :(_x_ = log(_y_m1_))
 
-julia> normalize("x = log(y(-1))")  # without targets
+julia> stringify("x = log(y(-1))")  # without targets
 :(log(_y_m1_) - _x_)
 ```
 
 ```@docs
-normalize(::Vector{Expr})
+stringify(::Vector{Expr})
 ```
 
 **Examples**:
 
 ```jldoctest
-julia> normalize([:(sin(x(0))), :(dot(x, y(1))), :(x = log(y(-1)))])
+julia> stringify([:(sin(x(0))), :(dot(x, y(1))), :(x = log(y(-1)))])
 quote
     sin(_x__0_)
     dot(_x_, _y__1_)
     log(_y_m1_) - _x_
 end
 
-julia> normalize([:(sin(x(0))), :(dot(x, y(1))), :(x = log(y(-1)))], targets=[:x])
+julia> stringify([:(sin(x(0))), :(dot(x, y(1))), :(x = log(y(-1)))], targets=[:x])
 quote
     sin(_x__0_)
     dot(_x_, _y__1_)
@@ -183,7 +183,7 @@ end
 ## `time_shift`
 
 `time_shift` shifts an expression by a specified number of time periods. As
-with normalize, there are many methods for this function, which will will
+with stringify, there are many methods for this function, which will will
 describe one at a time.
 
 ```@docs

--- a/experiments/process_equations/perf_import.py
+++ b/experiments/process_equations/perf_import.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 
 from dolang.triangular_solver import solve_triangular_system
 from dolang.symbolic import parse_string
-from dolang.symbolic import normalize, stringify_variable, stringify_parameter
+from dolang.symbolic import stringify, stringify_variable, stringify_parameter
 from dolang.codegen import to_source
 
 
@@ -48,7 +48,7 @@ with timeit("Parse equations"):
     equations = [parse_string(e) for e in equations]
 
 
-with timeit("Normalize equations"):
+with timeit("stringify equations"):
 
     all_variables = [(v, 1) for v in model['symbols']['variables']] + \
                     [(v, 0) for v in model['symbols']['variables']]  + \
@@ -58,32 +58,32 @@ with timeit("Normalize equations"):
     all_constants =  model['symbols']['parameters']
 
     # here comes the costly step
-    equations_normalized = [normalize(e, variables=all_vnames) for e in equations]
-    equations_normalized_strings = [to_source(e) for e in equations_normalized]
-    variables_normalized_strings = [stringify_variable(e) for e in all_variables]
+    equations_stringified = [stringify(e, variables=all_vnames) for e in equations]
+    equations_stringified_strings = [to_source(e) for e in equations_stringified]
+    variables_stringified_strings = [stringify_variable(e) for e in all_variables]
 
 
 stringify_variable( all_variables[-3] )
-equations_normalized_strings[-1]
+equations_stringified_strings[-1]
 
 with timeit("Sympify equations"):
-    equations_normalized_sympy = [sympy.sympify(e) for e in equations_normalized_strings]
+    equations_stringified_sympy = [sympy.sympify(e) for e in equations_stringified_strings]
 
 
 with timeit("Compute jacobian (sympy)"):
     jac = []
-    for eq in equations_normalized_strings:
+    for eq in equations_stringified_strings:
         line = []
         eqs = sympy.sympify(eq)
-        atoms = [v for v in eqs.atoms() if str(v) in variables_normalized_strings]
+        atoms = [v for v in eqs.atoms() if str(v) in variables_stringified_strings]
         for v in atoms:
             line.append(eqs.diff(v))
         jac.append(line)
 
 
 with timeit("Translate sympy - > symengine"):
-    atoms = [[symengine.sympify(v) for v in eq.atoms() if str(v) in variables_normalized_strings] for eq in equations_normalized_sympy]
-    eqs = [symengine.sympify(eq) for eq in equations_normalized_sympy]
+    atoms = [[symengine.sympify(v) for v in eq.atoms() if str(v) in variables_stringified_strings] for eq in equations_stringified_sympy]
+    eqs = [symengine.sympify(eq) for eq in equations_stringified_sympy]
 
 
 with timeit("Compute Jacobian and Hessian (symengine)"):

--- a/experiments/quickdef/quickdef.jl
+++ b/experiments/quickdef/quickdef.jl
@@ -1,4 +1,4 @@
-# normalized symbol for indexed variables
+# stringified symbol for indexed variables
 # a    -> :a
 # a(1) -> :a__f_
 # a(-1) -> :a__b_

--- a/src/Dolang.jl
+++ b/src/Dolang.jl
@@ -11,7 +11,7 @@ import Base: ==
 import REPL, SparseArrays
 
 using Printf
-export make_function, Der, FunctionFactory, normalize, is_time_shift, time_shift,
+export make_function, Der, FunctionFactory, stringify, is_time_shift, time_shift,
        subs, csubs, steady_state, list_symbols, list_symbols!, list_variables,
        list_parameters
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -24,7 +24,7 @@ _rhs_only(ex::Expr) =
     ex.head == :(=) ? Expr(:call, :(-), ex.args[2], ex.args[1]) : ex
 
 function _unpack_expr(names::Vector, rhs::Symbol)
-    _args = [:($(normalize(names[i])) = Dolang._unpack_var($rhs, $i))
+    _args = [:($(stringify(names[i])) = Dolang._unpack_var($rhs, $i))
              for i in 1:length(names)]
     out = Expr(:block); out.args = _args; out
 end
@@ -183,7 +183,7 @@ function _jacobian_expr_mat(ff::FunctionFactory{T}) where T<:FlatArgs
 
             if haskey(eq_incidence, v) && in(shift, eq_incidence[v])
                 non_zero += 1
-                my_deriv = deriv(eq_prepped, normalize(args[i_var]))
+                my_deriv = deriv(eq_prepped, stringify(args[i_var]))
                 exprs[i_eq, i_var] = post_deriv(my_deriv)
             end
         end
@@ -265,7 +265,7 @@ function _jacobian_expr_mat(ff::FunctionFactory{T}) where T<:GroupedArgs
 
                 if haskey(eq_incidence, v) && in(shift, eq_incidence[v])
                     non_zero[i] += 1
-                    my_deriv = deriv(eq_prepped, normalize(var))
+                    my_deriv = deriv(eq_prepped, stringify(var))
                     all_exprs[i][i_eq, i_var] = post_deriv(my_deriv)
                 end
             end
@@ -367,7 +367,7 @@ function make_deriv_loop(i::Int, der_order::Int)
     if i == der_order
         index_tuple = Expr(:tuple, [Symbol("iv_", j) for j in 1:i]...)
         inner_loop_guts = quote
-            $diff_sym = deriv($sym_to_diff, normalize(ff.args[$i_sym]))
+            $diff_sym = deriv($sym_to_diff, stringify(ff.args[$i_sym]))
 
             # might still be zero if terms were independent
             if $diff_sym != 0
@@ -377,7 +377,7 @@ function make_deriv_loop(i::Int, der_order::Int)
     else
         inner_loop_guts = Expr(
             :block,
-            :($diff_sym = deriv($sym_to_diff, normalize(ff.args[$i_sym]))),
+            :($diff_sym = deriv($sym_to_diff, stringify(ff.args[$i_sym]))),
             make_deriv_loop(i+1, der_order)
         )
     end

--- a/test/factory.jl
+++ b/test/factory.jl
@@ -89,7 +89,7 @@ end
         _FF = _FF
         ff = _FF(eqs, args, params, targets=targets, defs=defs, funname=funname)
 
-        # test that equations were normalized properly
+        # test that equations were stringified properly
         norm_eq1 = :(_foo__0_ = log(_a__0_) + _b__0_ / (_a_m1_ / (1 - _c__0_)))
         norm_eq2 = :(_bar__0_ = _c__1_ + _u_ * _d__1_)
         norm_eq = [norm_eq1, norm_eq2]
@@ -98,7 +98,7 @@ end
         # test that exceptions are thrown for unknown variables appearing
         # in the equations
         bad_eqs = vcat(eqs, :(whoami = a-b))::Vector{Expr}
-        @test_throws(Dolang.NormalizeError,
+        @test_throws(Dolang.stringifyError,
                      _FF(bad_eqs, args, params, targets=targets, defs=defs,
                          funname=funname))
 

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -5,35 +5,35 @@
     ex2 = :(z(0) == x + y(1))
 
     for ex in (ex1, ex2)
-        @test Dolang.normalize(ex) == :(_x_ + _y__1_ - _z__0_)
-        @test Dolang.normalize(ex, targets=[:_z__0_]) == :(_z__0_ = _x_ + _y__1_)
-        @test Dolang.normalize(ex, targets=[(:z, 0)]) == :(_z__0_ = _x_ + _y__1_)
+        @test Dolang.stringify(ex) == :(_x_ + _y__1_ - _z__0_)
+        @test Dolang.stringify(ex, targets=[:_z__0_]) == :(_z__0_ = _x_ + _y__1_)
+        @test Dolang.stringify(ex, targets=[(:z, 0)]) == :(_z__0_ = _x_ + _y__1_)
     end
 
 end
 
-@testset "Dolang.normalize" begin
-    @testset "Dolang.normalize(::Union{Symbol,String}, Integer)" begin
-        @test Dolang.normalize(:x, 0) == :_x__0_
-        @test Dolang.normalize(:x, 1) == :_x__1_
-        @test Dolang.normalize(:x, -1) == :_x_m1_
-        @test Dolang.normalize(:x, -100) == :_x_m100_
+@testset "Dolang.stringify" begin
+    @testset "Dolang.stringify(::Union{Symbol,String}, Integer)" begin
+        @test Dolang.stringify(:x, 0) == :_x__0_
+        @test Dolang.stringify(:x, 1) == :_x__1_
+        @test Dolang.stringify(:x, -1) == :_x_m1_
+        @test Dolang.stringify(:x, -100) == :_x_m100_
 
-        @test Dolang.normalize("x", 0) == :_x__0_
-        @test Dolang.normalize("x", 1) == :_x__1_
-        @test Dolang.normalize("x", -1) == :_x_m1_
-        @test Dolang.normalize("x", -100) == :_x_m100_
+        @test Dolang.stringify("x", 0) == :_x__0_
+        @test Dolang.stringify("x", 1) == :_x__1_
+        @test Dolang.stringify("x", -1) == :_x_m1_
+        @test Dolang.stringify("x", -100) == :_x_m100_
 
-        @test Dolang.normalize((:x, 0)) == :_x__0_
-        @test Dolang.normalize((:x, 1)) == :_x__1_
-        @test Dolang.normalize((:x, -1)) == :_x_m1_
-        @test Dolang.normalize((:x, -100)) == :_x_m100_
+        @test Dolang.stringify((:x, 0)) == :_x__0_
+        @test Dolang.stringify((:x, 1)) == :_x__1_
+        @test Dolang.stringify((:x, -1)) == :_x_m1_
+        @test Dolang.stringify((:x, -100)) == :_x_m100_
     end
 
     @testset "numbers" begin
         for T in (Float16, Float32, Float64, Int8, Int16, Int32, Int64)
             x = rand(T)
-            @test Dolang.normalize(x) == x
+            @test Dolang.stringify(x) == x
         end
     end
 
@@ -41,68 +41,68 @@ end
         for i=1:10
             s = gensym()
             want = Symbol("_", s, "_")
-            @test Dolang.normalize(s) == want
-            @test Dolang.normalize(want) == want
+            @test Dolang.stringify(s) == want
+            @test Dolang.stringify(want) == want
         end
     end
 
     @testset "x_(shift_Integer)" begin
         for i=1:10, T in (Int8, Int16, Int32, Int64)
-            @test Dolang.normalize(string("x(", T(i), ")")) == Symbol("_x__$(i)_")
-            @test Dolang.normalize(string("x(", T(-i), ")")) == Symbol("_x_m$(i)_")
+            @test Dolang.stringify(string("x(", T(i), ")")) == Symbol("_x__$(i)_")
+            @test Dolang.stringify(string("x(", T(-i), ")")) == Symbol("_x_m$(i)_")
         end
     end
 
     @testset "other function calls" begin
         @testset "one argument" begin
-            @test Dolang.normalize("sin(x)") == :(sin(_x_))
-            @test Dolang.normalize("sin(x(-1))") == :(sin(_x_m1_))
-            @test Dolang.normalize("foobar(x(2))") == :(foobar(_x__2_))
+            @test Dolang.stringify("sin(x)") == :(sin(_x_))
+            @test Dolang.stringify("sin(x(-1))") == :(sin(_x_m1_))
+            @test Dolang.stringify("foobar(x(2))") == :(foobar(_x__2_))
         end
 
         @testset "two arguments" begin
-            @test Dolang.normalize("dot(x, y(1))") == :(dot(_x_, _y__1_))
-            @test Dolang.normalize("plot(x(-1), y)") == :(plot(_x_m1_, _y_))
-            @test Dolang.normalize("bingbong(x(2), y)") == :(bingbong(_x__2_, _y_))
+            @test Dolang.stringify("dot(x, y(1))") == :(dot(_x_, _y__1_))
+            @test Dolang.stringify("plot(x(-1), y)") == :(plot(_x_m1_, _y_))
+            @test Dolang.stringify("bingbong(x(2), y)") == :(bingbong(_x__2_, _y_))
         end
 
         @testset "more args" begin
             for i=3:10
                 ex = Expr(:call, :my_func, [:(x($j)) for j in 1:i]...)
                 want = Expr(:call, :my_func, [Symbol("_x__", j, "_") for j in 1:i]...)
-                @test Dolang.normalize(ex) == want
+                @test Dolang.stringify(ex) == want
             end
         end
 
         @testset "arithmetic" begin
-            @test Dolang.normalize(:(a(1) + b + c(2) + d(-1))) == :(_a__1_ + _b_ + _c__2_ + _d_m1_)
-            @test Dolang.normalize(:(a(1) * b * c(2) * d(-1))) == :(_a__1_ * _b_ * _c__2_ * _d_m1_)
-            @test Dolang.normalize(:(a(1) - b - c(2) - d(-1))) == :(((_a__1_ - _b_) - _c__2_) - _d_m1_)
-            @test Dolang.normalize(:(a(1) ^ b)) == :(_a__1_ ^ _b_)
+            @test Dolang.stringify(:(a(1) + b + c(2) + d(-1))) == :(_a__1_ + _b_ + _c__2_ + _d_m1_)
+            @test Dolang.stringify(:(a(1) * b * c(2) * d(-1))) == :(_a__1_ * _b_ * _c__2_ * _d_m1_)
+            @test Dolang.stringify(:(a(1) - b - c(2) - d(-1))) == :(((_a__1_ - _b_) - _c__2_) - _d_m1_)
+            @test Dolang.stringify(:(a(1) ^ b)) == :(_a__1_ ^ _b_)
         end
 
         @testset "throws errors when unsupported" begin
-            @test_throws Dolang.NormalizeError Dolang.normalize("x+y || i <= 100")
+            @test_throws Dolang.stringifyError Dolang.stringify("x+y || i <= 100")
         end
     end
 
     @testset "Expr(:(=), ...)" begin
         @testset "without targets" begin
-            @test Dolang.normalize(:(x = y)) == :(_y_ - _x_)
+            @test Dolang.stringify(:(x = y)) == :(_y_ - _x_)
         end
 
         @testset "with targets" begin
-            @test Dolang.normalize(:(x = log(y(-1))); targets=[:x]) == :(_x_ = log(_y_m1_))
-            @test Dolang.normalize(:(x == log(y(-1))); targets=[:x]) == :(_x_ = log(_y_m1_))
-            @test_throws Dolang.NormalizeError Dolang.normalize(:(x = y); targets=[:y])
+            @test Dolang.stringify(:(x = log(y(-1))); targets=[:x]) == :(_x_ = log(_y_m1_))
+            @test Dolang.stringify(:(x == log(y(-1))); targets=[:x]) == :(_x_ = log(_y_m1_))
+            @test_throws Dolang.stringifyError Dolang.stringify(:(x = y); targets=[:y])
         end
     end
 
-    @testset "normalize(::Tuple{Symbol,Int})" begin
-        @test Dolang.normalize((:x, 0)) == :_x__0_
-        @test Dolang.normalize((:x, 1)) == :_x__1_
-        @test Dolang.normalize((:x, -1)) == :_x_m1_
-        @test Dolang.normalize((:x, -100)) == :_x_m100_
+    @testset "stringify(::Tuple{Symbol,Int})" begin
+        @test Dolang.stringify((:x, 0)) == :_x__0_
+        @test Dolang.stringify((:x, 1)) == :_x__1_
+        @test Dolang.stringify((:x, -1)) == :_x_m1_
+        @test Dolang.stringify((:x, -100)) == :_x_m100_
     end
     
 end


### PR DESCRIPTION
@sglyon : we discussed this trivial change a while ago. Avoids type piracy with LinearAlgebra. I'd like to merge that one before we do a release. 