### PR TITLE
ENH (julia): initial implementation of yaml minilanguage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   # - osx  # we don't do any binary dependencies or OS specific magic
 julia:
     - 1.0
+    - 1.1
     - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.7
 DataStructures
 SymEngine
 StaticArrays
+YAML

--- a/src/Dolang.jl
+++ b/src/Dolang.jl
@@ -41,8 +41,7 @@ include("factory.jl")
 include("util.jl")
 include("compiler.jl")
 include("compiler_new.jl")
-
 include("printing.jl")
-
+include("minilanguage.jl")
 
 end  # module

--- a/src/minilanguage.jl
+++ b/src/minilanguage.jl
@@ -79,7 +79,7 @@ const yaml_basis_tags = [
 #     return data
 # end
 
-function yaml_node_from_string(txt::AbstractString, minilanguage::Language)
+function yaml_node_from_string(txt::AbstractString, minilanguage::Language=Language())
     # Didn't find how to access the top node more easily.
     #
     yml_types = Dict{AbstractString,Function}()
@@ -92,7 +92,7 @@ function yaml_node_from_string(txt::AbstractString, minilanguage::Language)
     return YAML.load(txt, yml_types)
 end
 
-function yaml_node_from_file(fn::AbstractString, minilanguage::Language)
+function yaml_node_from_file(fn::AbstractString, minilanguage::Language=Language())
     txt = open(f->read(f,String), fn)
     txt = replace(txt, "\r"=>"")
     return yaml_node_from_string(txt, minilanguage)
@@ -254,7 +254,13 @@ function eval_node(node::YAML.SequenceNode, calibration::AbstractDict{Symbol, <:
     children = [eval_node(ch, calibration, minilang, greek_tol) for ch in node]
     tag = node.tag
     if tag == "tag:yaml.org,2002:seq"
-        return children
+        if typeof(children) <: Vector{Vector{Float64}}
+            res = vcat([x' for x in children]...)
+            println(res)
+            return res
+        else
+            return children
+        end
     else # custom object with positional arguments
         childs = tuple(children...)
         try

--- a/src/minilanguage.jl
+++ b/src/minilanguage.jl
@@ -1,0 +1,294 @@
+import YAML
+
+
+# convenience extensions of YAML library
+import Base.getindex
+import Base.keys
+import Base.values
+
+Base.length(d::YAML.SequenceNode) = length(d.value)
+Base.getindex(d::YAML.SequenceNode, k::Integer) = d.value[k]
+Base.iterate(d::YAML.SequenceNode, state=1)  = state>length(d) ? nothing : (d.value[state], state+1)
+Base.keys(s::YAML.MappingNode) =  [e[1].value for e=s.value]
+Base.values(s::YAML.MappingNode) =  [e[2].value for e=s.value]
+Base.getindex(d::YAML.MappingNode, s::AbstractString) = d.value[findfirst(isequal(s),keys(d))][2]
+Base.iterate(d::YAML.MappingNode, state=1)  = state>length(d) ? nothing : ((d.value[state][1].value=>d.value[state][2]), state+1)
+Base.getindex(d::YAML.MappingNode, s::Symbol) = d[string(s)]
+Base.length(d::YAML.MappingNode) = length(d.value)
+
+const symbols_from_greek = Dict(
+    :μ=>:mu,
+    :σ=>:sigma,
+    :Σ=>:Sigma,
+    :ρ=>:rho,
+    :λ=>:lambda,
+    :β=>:beta,
+    :δ=>:delta
+)
+const symbols_to_greek = Dict(v=>k for (k,v) in symbols_from_greek)
+
+#
+#  Language object: essentially a table from tag to a constructor
+#
+
+struct Language
+    objects::Dict{String, Any}
+end
+
+Language() = Language(Dict{String, Any}())
+
+function add_language_element!(lang, fun, tag::AbstractString)
+    lang.objects[tag] = fun
+end
+function add_language_element!(lang, fun, tags::Vector{AbstractString})
+    for tag in tags
+        add_language_element!(lang, fun, tag)
+    end
+end
+function add_language_elements!(lang, elts::AbstractDict{<:AbstractString, <:Any})
+    for (k,v) in elts
+        add_language_element!(lang, v, k)
+    end
+end
+
+####
+#### Functions to import yaml tree (with locations and tags)
+####
+
+const yaml_basis_tags = [
+    "tag:yaml.org,2002:null",
+    "tag:yaml.org,2002:bool",
+    "tag:yaml.org,2002:int",
+    "tag:yaml.org,2002:float",
+    "tag:yaml.org,2002:binary",
+    "tag:yaml.org,2002:timestamp",
+    "tag:yaml.org,2002:omap",
+    "tag:yaml.org,2002:pairs",
+    "tag:yaml.org,2002:set",
+    "tag:yaml.org,2002:str",
+    "tag:yaml.org,2002:seq",
+    "tag:yaml.org,2002:map",
+]
+
+# with upcoming version of YAML.jl
+# function yaml_node_from_string(txt::AbstractString)
+#     cons = YAML.Constructor()
+#     YAML.add_multi_constructor!((c,s,m)->m, cons, "tag:yaml.org")
+#     YAML.add_multi_constructor!((c,s,m)->m, cons, "!")
+#     data = YAML.load(txt, cons)
+#     return data
+# end
+
+function yaml_node_from_string(txt::AbstractString, minilanguage::Language)
+    # Didn't find how to access the top node more easily.
+    #
+    yml_types = Dict{AbstractString,Function}()
+    for tag in yaml_basis_tags
+        yml_types[tag] = (c,n)->n
+    end
+    for tag in keys(minilanguage.objects)
+        yml_types[tag] = (c,n)->n
+    end
+    return YAML.load(txt, yml_types)
+end
+
+function yaml_node_from_file(fn::AbstractString, minilanguage::Language)
+    txt = open(f->read(f,String), fn)
+    txt = replace(txt, "\r"=>"")
+    return yaml_node_from_string(txt, minilanguage)
+end
+
+##
+# Function to evaluate string from calibration
+#
+# TODO: not safe and hazardous error policy
+##
+
+function eval_string(s::AbstractVector{Expr}, d:: AbstractDict{Symbol, <:Number})
+
+        # extract expressions and variable names in proper order
+        nms = collect(keys(d))
+        exprs = collect(values(d))
+
+        # build expression to Core.evaluate system in correct order
+        to_eval = Expr(:block)
+        to_eval.args = [:($(i[1])=$(i[2])) for i in zip(nms, exprs)]
+
+        # add one line to return a tuple of all data
+        ret = Expr(:tuple); ret.args = s
+
+        # now Core.evaluate and get data
+        expr = :(
+            let
+                $to_eval
+                $ret
+            end
+        )
+        data = eval(expr)
+end
+
+eval_string(s::Expr, d::AbstractDict{Symbol, <:Number}) = eval_string([s], d)[1]
+
+function eval_string(s::AbstractString, d::AbstractDict{Symbol, <:Number}=Dict{Symbol, Float64}())
+        expr = Meta.parse(s)
+        eval_string(expr, d)
+end
+
+###
+# Some errors potentially occuring when parsing yaml structure
+##
+
+struct Position
+    l1::Int
+    c1::Int
+    l2::Int
+    c2::Int
+end
+
+abstract type LanguageError <: Exception end
+
+struct ParsingError{T<:LanguageError} <: Exception
+    pos::Position
+    error::T
+end
+
+function ParsingError(node::YAML.Node, error)
+    ms, em = node.start_mark, node.end_mark
+    l1, c1 = Int(ms.line), Int(ms.column)
+    l2, c2 = Int(em.line), Int(em.column)
+    pos = Position(l1, c1, l2, c2)
+    return ParsingError(pos, error)
+end
+
+
+struct LangInvalidCall <: LanguageError
+    tag::String
+    err::MethodError
+end
+
+struct LangUnknownTag <: LanguageError
+    tag::String
+end
+
+function message(e::LangInvalidCall)
+    s = IOBuffer()
+    showerror(s, e.err)
+    msg = String(take!(s))
+    return msg
+end
+message(e::LangUnknownTag) = "Unknown tag: \"$(e.tag)\""
+
+Base.showerror(io::IO, e::LanguageError) = print(io, message(e))
+Base.showerror(io::IO, e::ParsingError) = print(io, "Language Error: $(e.pos.l1), $(e.pos.l2): $(message(e.error)))")
+
+#
+# construct object from tag and arguments
+#
+
+function construct_object(lang, tag, args::AbstractDict{<:Any,<:Any})
+    if !( tag in keys(lang.objects))
+        throw(LangUnknownTag(tag))
+    end
+    constructor = lang.objects[tag]
+    try
+        return constructor(;args...)
+    catch err
+        throw( LangInvalidCall(tag, err) )
+    end
+end
+
+function construct_object(lang, tag, args)
+    if !(tag in keys(lang.objects))
+        throw(LangUnknownTag(tag))
+    end
+    constructor = lang.objects[tag]
+    try
+        return constructor(args...)
+    catch err
+        throw( LangInvalidCall(tag, err) )
+    end
+end
+
+#
+# option types
+# maybe this is not needed anymore thanks to constant propagation
+
+abstract type GreekTolerance end
+struct FromGreek<:GreekTolerance
+    # greek characters are automatically converted to alphanumerical
+end
+struct ToGreek<:GreekTolerance
+    # alphanumerical characters are automatically converted to greek
+end
+struct NoGreek<:GreekTolerance
+    # no conversion
+end
+
+###
+# evaluate yaml structures
+#
+
+
+# scalar: text, float, int, ...
+function eval_node(s::YAML.ScalarNode, calibration::AbstractDict{Symbol, <:Number}, minilang::Language=Language(), greek_tol::GreekTolerance=NoGreek())
+    v = s.value
+    tag = s.tag
+    if tag == "tag:yaml.org,2002:str"
+        return try
+            eval_string(v, calibration)
+        catch err
+            # TODO: fix behaviour when type is not recognized
+            v
+        end
+    elseif tag == "tag:yaml.org,2002:int"
+        return parse(Int, v)
+    elseif tag == "tag:yaml.org,2002:float"
+        return parse(Float64, v)
+    end
+end
+
+
+
+# sequences
+function eval_node(node::YAML.SequenceNode, calibration::AbstractDict{Symbol, <:Number}, minilang::Language=Language(), greek_tol::GreekTolerance=NoGreek())
+    children = [eval_node(ch, calibration, minilang, greek_tol) for ch in node]
+    tag = node.tag
+    if tag == "tag:yaml.org,2002:seq"
+        return children
+    else # custom object with positional arguments
+        childs = tuple(children...)
+        try
+            return construct_object(minilang, tag, childs)
+        catch err
+            throw(ParsingError(node, err))
+        end
+    end
+end
+
+# map
+function eval_node(node::YAML.MappingNode, calibration::AbstractDict{Symbol, <:Number}, minilang::Language=Language(), greek_tol::GreekTolerance=NoGreek())
+    d = Dict()
+    for i=1:length(node)
+        k = Symbol(node.value[i][1].value)
+        if typeof(greek_tol)<:FromGreek
+            if haskey(symbols_from_greek, k)
+                k = symbols_from_greek[k]
+            end
+        elseif typeof(greek_tol)<:ToGreek
+            if haskey(symbols_to_greek, k)
+                k = symbols_to_greek[k]
+            end
+        end
+        v = eval_node(node.value[i][2], calibration, minilang, greek_tol)
+        d[k] = v
+    end
+    if node.tag == "tag:yaml.org,2002:map"
+        return d
+    else # custom object with positional arguments
+        try
+            return construct_object(minilang, node.tag, d)
+        catch err
+            throw(ParsingError(node, err))
+        end
+    end
+end

--- a/test/minilanguage.jl
+++ b/test/minilanguage.jl
@@ -1,11 +1,3 @@
-@testset "minilanguage" begin
-
-
-import Dolang: Language, construct_object, add_language_elements!, eval_node
-import Dolang: FromGreek, ToGreek
-import Dolang: LangInvalidCall, LangUnknownTag, ParsingError, yaml_node_from_file
-# the two objects replace  imports from Dolo
-
 struct MvNormal
     mu::Vector{Float64}
     Sigma::Matrix{Float64}
@@ -16,6 +8,15 @@ struct Cartesian
     b::Vector{Float64}
     orders::Vector{Int64}
 end
+
+@testset "minilanguage" begin
+
+
+import Dolang: Language, construct_object, add_language_elements!, eval_node
+import Dolang: FromGreek, ToGreek
+import Dolang: LangInvalidCall, LangUnknownTag, ParsingError, yaml_node_from_file
+# the two objects replace  imports from Dolo
+
 
 # we create a mini-language with two keywords:
 # UNormal(μ=0.0, σ=1.0) # keyword object with greek arguments

--- a/test/minilanguage.jl
+++ b/test/minilanguage.jl
@@ -1,0 +1,94 @@
+@testset "minilanguage" begin
+
+
+import Dolang: Language, construct_object, add_language_elements!, eval_node
+import Dolang: FromGreek, ToGreek
+import Dolang: LangInvalidCall, LangUnknownTag, ParsingError, yaml_node_from_file
+# the two objects replace  imports from Dolo
+
+struct MvNormal
+    mu::Vector{Float64}
+    Sigma::Matrix{Float64}
+end
+
+struct Cartesian
+    a::Vector{Float64}
+    b::Vector{Float64}
+    orders::Vector{Int64}
+end
+
+# we create a mini-language with two keywords:
+# UNormal(μ=0.0, σ=1.0) # keyword object with greek arguments
+# Cartesian # positional
+
+
+UNormal(;μ::Float64=0.0,σ::Float64=1.0) = MvNormal([μ], σ*ones(1,1))
+minilang = Language(Dict())
+add_language_elements!(minilang, Dict(
+    "!Cartesian"=>Cartesian,
+    "!UNormal"=>UNormal
+))
+
+obj = construct_object(minilang, "!UNormal", Dict(:σ=>0.1, :μ=> 0.001))
+@assert typeof(obj) <: MvNormal
+
+obj = construct_object(minilang, "!Cartesian", ([0.0], [1.0], [20]))
+@assert typeof(obj) <: Cartesian
+
+# UNormal doesn't take positional arguments:
+@test_throws LangInvalidCall construct_object(minilang, "!UNormal", (0.1, 0.001))
+@test_throws LangInvalidCall construct_object(minilang, "!Cartesian", ([0.0], [1.0]) )
+@test_throws LangUnknownTag construct_object(minilang, "!NonExisting", ([0.0], [1.0], [20]) )
+
+
+##
+
+calibration = Dict(:a=>0.2, :b=>0.5)
+
+# use test file
+
+data = yaml_node_from_file("minilanguage.yaml", minilang)
+
+# evaluate terminal nodes directly
+res = eval_node( data["equations"][1], calibration )
+@assert res == 0.7
+
+# if expression is not recognized or calibration not given, expression is returned as such
+res = eval_node( data["equations"][2], calibration )
+@assert res=="a + b + c"
+
+# one can evaluate a yaml list directly
+res = eval_node( data["equations"], calibration)
+@assert res[1] == 0.7
+@assert res[2] == "a + b + c"
+@assert res[3] == 8
+@assert res[4] == 9.0 # we return same types as parsed by yaml
+
+
+# this raises a parsing exception
+@test_throws ParsingError{LangUnknownTag} eval_node(data["exogenous"], calibration)
+@test_throws ParsingError{LangUnknownTag} eval_node(data["shocks"], calibration)
+
+# evaluate typed section
+gg = eval_node(data["grid"], calibration, minilang)
+@test typeof(gg) <: Cartesian
+gg = eval_node(data["exogenous"], calibration, minilang)
+@test typeof(gg) <: MvNormal
+
+# test greek tolerance
+
+gg = eval_node(data["calibration"], calibration, minilang)
+@test tuple(sort([keys(gg)...])... ) == (:mu, :β, :λ, :σ)
+
+gg = eval_node(data["calibration"], calibration, minilang, FromGreek())
+@test tuple(sort([keys(gg)...])... ) == ( :beta, :lambda, :mu, :sigma)
+
+
+@test_throws ParsingError{LangInvalidCall} eval_node(data["exogenous2"], calibration, minilang)
+@test_throws ParsingError{LangInvalidCall} eval_node(data["exogenous2"], calibration, minilang, FromGreek())
+
+# that one works because object !
+gg = eval_node(data["exogenous2"], calibration, minilang, ToGreek())
+typeof(gg) <: MvNormal
+
+end

--- a/test/minilanguage.yaml
+++ b/test/minilanguage.yaml
@@ -1,0 +1,31 @@
+calibration:
+  σ: 0.1
+  β: 0.1
+  mu: 0.5
+  λ: "a+b"
+
+
+exogenous: !UNormal
+  μ: 0.1
+  σ: 0.1
+
+exogenous2: !UNormal
+  μ: 0.1
+  sigma: 0.1
+
+equations:
+  - a + b
+  - a + b + c
+  - 8
+  - 9.0
+
+shocks: !Product
+  - a + b
+  - a + b + c
+  - 8
+  - 9.0
+
+grid: !Cartesian
+  - [2.0, 2.0]
+  - [5.0, 4.0]
+  - [20, 20.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,5 +25,6 @@ include("compiler.jl")
 include("compiler_new.jl")
 include("util.jl")
 include("printing.jl")
+include("minilanguage.jl")
 
 end


### PR DESCRIPTION
@sglyon: if and only if you are curious.
This PR implements a new way of parsing objects from the YAML file, using commented objects from YAML.jl instead of a dict of dict structure. This allows for better error messages, and, in the future some useful type checking. Model construction in Dolo.jl, will be rewritten using it.
It is already implemented in Python using ruamel.yaml (https://github.com/EconForge/dolo/pull/161).

The main method is `eval_node(node, calibration, minilanguage)` where the first element is the result from `yaml.jl`, the second a presolved calibration, and minilanguage an object defining which types are allowed. String leafs which can be evaluated with the calibration are replaced by a float, else i remain strings.
There is a greek tolerance feature: it is possible to automatically convert greek characters to unicode so that both `AR1(rho=0.98, sigma=0.1)` and `AR1(ρ=0.98, σ=0.1)` can be accepted in the yaml file.
Also, lists of lists of floats are automatically converted to matrices.
