### PR TITLE
compat: Support upcoming TypeEgal Val wrappers

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -557,7 +557,13 @@ end
 # genfun((Val(1),Val(2)), x, y, z, p, out=)
 # where the first argument denotes the arguments to differentiate with (0, is zero-order diff)
 
-_get_nums(::Union{Val{n}, Type{Val{n}}, Type{Type{Val{n}}}}) where n = n
+_get_nums(::Val{n}) where n = n
+_get_nums(::Type{Val{n}}) where n = n
+if isdefined(Core, :TypeEgal)
+    _get_nums(T::Union{Core.TypeEq, Core.TypeEgal}) = _get_nums(Base.type_parameter(T))
+else
+    _get_nums(::Type{Type{Val{n}}}) where n = n
+end
 _get_nums(t::Type{<:Tuple}) = [_get_nums(i) for i in getfield(t, 3)]
 _get_oorders(x::Array{Int,0}) = x[1]
 _get_oorders(x::Union{Tuple,<:Array{Int}}) = x


### PR DESCRIPTION
The Base PR JuliaLang/julia#62001 is expected to spell exact closed type-object dispatch keys as Core.TypeEgal. Accept Core.TypeEq and Core.TypeEgal generated-function dispatch wrappers when they are available, while preserving the existing Type{Type{Val{T}}} path on older Julia versions.

A <:T-style signature would also accept the new spelling, as discussed in Ferrite-FEM/Tensors.jl#249. The structural unwrap used here asks slightly less of the compiler, since it avoids solving the extra subtype relation in this generated-function helper path.

AI disclosure: This commit was prepared with assistance from generative AI. The resulting PR should be checked carefully by a maintainer before merging.